### PR TITLE
第4章Rails風味のRuby 4.1 動機

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+    
+    # ページごとの完全なタイトルを返します
+    def full_title(page_title = '')
+        base_title = "Ruby on Rails Tutorial Sample App"
+        if page_title.empty?
+            base_title
+        else
+            page_title + " | " + base_title
+        end
+    end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= yield(:title) %> | Ruby on Rails Tutorial Sample App</title>
+    <title><%= full_title(yield(:title)) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,4 +1,3 @@
-<% provide(:title, "Home") %>
 <h1>Sample App</h1>
 <p>
   This is the home page for the

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -14,7 +14,7 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
   test "should get home" do
     get static_pages_home_url
     assert_response :success
-    assert_select "title", "Home | #{@base_title}"
+    assert_select "title", "#{@base_title}"
   end
 
   test "should get help" do


### PR DESCRIPTION
# 4.1 動機
## 4.1.1 組み込みヘルパー
ソース変更なし
```html:application.html.erb
<%= stylesheet_link_tag 'application', media: 'all',
                                       'data-turbolinks-track': 'reload' %>
```
この１行に
- stylesheet_link_tagのRailsの組み込み関数
- カッコを使わないメソッド呼び出し
- シンボル
- ハッシュ

が使用されているということがわかりました

## 4.1.2 カスタムヘルパー
**full_title**ヘルパーを`application_helper.rb`に定義
```ruby
module ApplicationHelper

  # ページごとの完全なタイトルを返します。
  def full_title(page_title = '')
    base_title = "Ruby on Rails Tutorial Sample App"
    if page_title.empty?
      base_title
    else
      page_title + " | " + base_title
    end
  end
end
```

これにより、固有のページ名が設定されているものは先頭にそのページ名`Hoge | Ruby on Rails Tutorial Sample App`、
設定されていないものはデフォルトタイトル`Ruby on Rails Tutorial Sample App`が表示されるようになりました。
それに伴い、`application.html.erb`でタイトル表示箇所をそのヘルパーに置き換え、
Homeページは固有のページ名を指定する記述を削除しています。

### 画像
![image](https://user-images.githubusercontent.com/23697407/99137943-6ce3e780-2670-11eb-8044-6e674f40dc3f.png)
