### PR TITLE
6.3 セキュアなパ スワードを追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'rails',      '6.0.3'
+gem 'bcrypt',         '3.1.13'
 gem 'bootstrap-sass', '3.4.1'
 gem 'puma',       '4.3.4'
 gem 'sass-rails', '5.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     ansi (1.5.0)
     autoprefixer-rails (10.0.2.0)
       execjs
+    bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
@@ -246,6 +247,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt (= 3.1.13)
   bootsnap (= 1.4.5)
   bootstrap-sass (= 3.4.1)
   byebug (= 11.0.1)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+
     # before_save { self.email = email.downcase }
     before_save { email.downcase! }
     validates :name, presence: true, length: { maximum: 50 }
@@ -7,5 +8,7 @@ class User < ApplicationRecord
     validates :email, presence: true, length: { maximum: 255 },
                         format: { with: VALID_EMAIL_REGEX },
                         uniqueness: true
+    has_secure_password
+    validates :password, presence: true, length: {minimum: 6}
                         
 end

--- a/db/migrate/20201128062045_add_password_digest_to_users.rb
+++ b/db/migrate/20201128062045_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_26_090209) do
+ActiveRecord::Schema.define(version: 2020_11_28_062045) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "password_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 class UserTest < ActiveSupport::TestCase
   
   def setup
-    @user = User.new(name: "Example User", email: "user@example.com")
+    @user = User.new(name: "Example User", email: "user@example.com",
+                     password: "foobar", password_confirmation: "foobar")
   end
   
   test "should be valid" do
@@ -61,4 +62,13 @@ class UserTest < ActiveSupport::TestCase
     assert_equal mixed_case_email.downcase, @user.reload.email
   end
   
+  test "password should be present (nonblank)" do
+    @user.password = @user.password_confirmation = " " * 6
+    assert_not @user.valid?
+  end
+  
+  test "password should have a minimum legth" do
+    @user.password = @user.password_confirmation = "a" * 5
+    assert_not @user.valid?
+  end
 end


### PR DESCRIPTION
## 概要
### usersテーブルにパスワード(`password_digest`)のカラムを追加
`$ rails generate migration add_password_digest_to_users password_digest:string`
を実行。末尾を`to_users`にすることで、usersテーブルにカラムを追加するマイグレーションが自動的に生成される。
`$ rails db:migrate`
で反映。

### パスワードをハッシュ化するために`bcrypt`をGemfileに追加
Userモデル内で`has_secure_password`を使用してパスワードをハッシュ化する。
ハッシュ化されたパスワードをDBに登録することで、セキュリティを強化する。
ログイン等でパスワードを比較する際は、ハッシュ化されたパスワード同士を比較し、同じであればOK。

### パスワードは6文字以上で必須とする
文字数の制限と空文字を制限するために、`user.rb`に以下のように追加する
`validates :password, presence: true, length: { minimum: 6 }`

### authenticateメソッド
`has_secure_password`をUserモデルに追加したことで、`authenticate`メソッドが使用できるようになる。
これは引数の文字列をハッシュ化し、データベース内の`password_digest`カラムの値を比較してくれる。
比較した結果が違った場合は、`false`が返ってくるが、
同じだった場合はそのオブジェクトが返却される。
そのため、同じかどうかを真偽値で確認したい場合は
false/nil以外はtrueとして扱えることを利用し
`!!user.authenticate("foobar")`
と記述すれば、trueが返却される。

