### PR TITLE
8.3 ログアウト

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,5 +16,7 @@ class SessionsController < ApplicationController
   end
   
   def destroy
+    log_out
+    redirect_to root_url
   end
 end

--- a/app/controllers/users_controller.rb_
+++ b/app/controllers/users_controller.rb_
@@ -1,4 +1,0 @@
-class UsersController < ApplicationController
-  def new
-  end
-end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,11 +2,11 @@ module ApplicationHelper
 
   # ページごとの完全なタイトルを返します。                   # コメント行
   def full_title(page_title = '')                     # メソッド定義とオプション引数
-    base_title = "Ruby on Rails Tutorial Sample App"  # 変数への代入
+    base_title = 'Ruby on Rails Tutorial Sample App'  # 変数への代入
     if page_title.empty?                              # 論理値テスト
       base_title                                      # 暗黙の戻り値
     else
-      page_title + " | " + base_title                 # 文字列の結合
+      page_title + ' | ' + base_title                 # 文字列の結合
     end
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -15,4 +15,9 @@ module SessionsHelper
     def logged_in?
         !current_user.nil?
     end
+    
+    def log_out
+        session.delete(:user_id)
+        @current_user = nil
+    end
 end

--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -4,17 +4,17 @@ class SiteLayoutTest < ActionDispatch::IntegrationTest
   # test "the truth" do
   #   assert true
   # end
-  test "layout links" do
+  test 'layout links' do
     get root_path
     assert_template 'static_pages/home'
-    assert_select "a[href=?]", root_path, count: 2
-    assert_select "a[href=?]", help_path
-    assert_select "a[href=?]", about_path
-    assert_select "a[href=?]", contact_path
-    assert_select "a[href=?]", signup_path
+    assert_select 'a[href=?]', root_path, count: 2
+    assert_select 'a[href=?]', help_path
+    assert_select 'a[href=?]', about_path
+    assert_select 'a[href=?]', contact_path
+    assert_select 'a[href=?]', signup_path
     get contact_path
-    assert_select "title", full_title("Contact")
+    assert_select 'title', full_title('Contact')
     get signup_path
-    assert_select "title", full_title("Sign up")
+    assert_select 'title', full_title('Sign up')
   end
 end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -5,26 +5,35 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     @user = users(:michael)
   end
   
-  test "login with valid email/invalid password" do
+  test 'login with valid email/invalid password' do
     get login_path
     assert_template 'sessions/new'
     post login_path, params: { session: { email:    @user.email,
                                           password: "invalid" } }
+    assert_not is_logged_in?
     assert_template 'sessions/new'
     assert_not flash.empty?
     get root_path
     assert flash.empty?
   end
 
-  test "login with valid information" do
+  test 'login with valid information followed by logout' do
     get login_path
     post login_path, params: { session: { email:    @user.email,
                                           password: 'password' } }
+    assert is_logged_in?
     assert_redirected_to @user
     follow_redirect!
     assert_template 'users/show'
-    assert_select "a[href=?]", login_path, count: 0
-    assert_select "a[href=?]", logout_path
-    assert_select "a[href=?]", user_path(@user)
+    assert_select 'a[href=?]', login_path, count: 0
+    assert_select 'a[href=?]', logout_path
+    assert_select 'a[href=?]', user_path(@user)
+    delete logout_path
+    assert_not is_logged_in?
+    assert_redirected_to root_url
+    follow_redirect!
+    assert_select 'a[href=?]', login_path
+    assert_select 'a[href=?]', logout_path,      count: 0
+    assert_select 'a[href=?]', user_path(@user), count: 0
   end
 end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class UsersSignupTest < ActionDispatch::IntegrationTest
   
-  test "invalid signup information" do
+  test 'invalid signup information' do
     get signup_path
     assert_no_difference 'User.count' do
       post users_path, params: { user: { name: '',
@@ -13,7 +13,7 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_template 'users/new'
   end
   
-  test "valid signup information" do
+  test 'valid signup information' do
     get signup_path
     assert_difference 'User.count', 1 do
       post users_path, params: { user: { name:  'Example User',


### PR DESCRIPTION
## 概要
ログアウト機能の実装

```sessions_helper.rb
  # 現在のユーザーをログアウトする
  def log_out
    session.delete(:user_id)
    @current_user = nil
  end
```
として、セッションからユーザIDを削除するメソッドを作成し、controllerのdestroyアクションで呼び出す
```sessions_controller.rb
  def destroy
    log_out
    redirect_to root_url
  end
```

ルートURLにリダイレクトしトップ画面を表示させる。

## 画像
![1210](https://user-images.githubusercontent.com/23697407/101717691-25bc0b80-3ae3-11eb-87e7-8166c390a43a.gif)



あと、色々とシングルクォートに統一したほうがいいのかなと思い、ダブルクォート→シングルクォートに直す作業を、気付いたものから合間に少しずつ挟んでいこうと考えてます！（一気にやると変更が大量になってしまいそうなので…！）

